### PR TITLE
Add deprecated classes and functions

### DIFF
--- a/mesa/space.py
+++ b/mesa/space.py
@@ -335,6 +335,17 @@ class Grid:
     def position_agent(self, agent, x="random", y="random"):
         self.place_agent(agent, (x, y))
 
+    def get_cell_list_contents(self, cells):
+        if not isinstance(cells, list):
+            cells = [cells]
+        return [self.grid[cell[0]][cell[1]] for cell in cells]
+
+    def iter_cell_list_contents(self, cells):
+        if not isinstance(cells, list):
+            cells = [cells]
+        for cell in cells:
+            yield self.grid[cell[0]][cell[1]]
+
 
 class SingleGrid(Grid):
     """Depreciated class."""


### PR DESCRIPTION
Fixed several bugs:

No return statements for _moore and _neumann

Your grid initiating had x and y mixed up. Also, it doesn't work that elegantly because you are creating references to the same None type. So if you add an agent it gets added to the whole row (or column, I don't remember)

Added back in some functions to make the tests work. These should include a deprecating warning (in the docstring and as a `warnings.warn`)

